### PR TITLE
Clarifying conclusion about miscommunication

### DIFF
--- a/words.html
+++ b/words.html
@@ -876,8 +876,8 @@ a game where it's at least possible that <i>both</i> players can be better off -
 3. LOW MISCOMMUNICATION
 </p>
 <p id="conclusion_3_a2">
-The level of miscommunication can't be <i>too</i> high.
-And when there's a little bit of miscommunication, it pays to be <i>more</i> forgiving.
+Trust will break down if the level of miscommunication is <i>too</i> high.
+But when there's a little bit of miscommunication, it pays to be <i>more</i> forgiving.
 </p>
 <p id="conclusion_4">
 Of course, real-world trust is affected by much more than this.


### PR DESCRIPTION
When I first read this:
> The level of miscommunication can't be <i>too</i> high.

I thought you were trying to say:

> The level of miscommunication has no limit and can always go higher.

Hope this helps make the actual meaning more explicit.
