### PR TITLE
* Shuffle agents before sorting.

### DIFF
--- a/js/lib/helpers.js
+++ b/js/lib/helpers.js
@@ -174,3 +174,14 @@ function _makeMovieClip(resourceName, options){
 	return mc;
 
 }
+
+function _shuffleArray(array) {
+	var tmp, current, top = array.length;
+	if(top) while(--top) {
+		current = Math.floor(Math.random() * (top + 1));
+		tmp = array[current];
+		array[current] = array[top];
+		array[top] = tmp;
+	}
+	return array;
+}

--- a/js/sims/Tournament.js
+++ b/js/sims/Tournament.js
@@ -229,11 +229,8 @@ function Tournament(config){
 	self.agentsSorted = null;
 	self.playOneTournament = function(){
 		PD.playOneTournament(self.agents, Tournament.NUM_TURNS);
-		self.agentsSorted = self.agents.slice();
-		self.agentsSorted.sort(function(a,b){
-			if(a.coins==b.coins) return (Math.random()<0.5); // if equal, random
-			return a.coins-b.coins; // otherwise, sort as per usual
-		});
+		self.agentsSorted = _shuffleArray(self.agents.slice());
+		self.agentsSorted.sort(function(a,b){ return a.coins-b.coins; });
 	};
 
 	// Get rid of X worst


### PR DESCRIPTION
  Without this fix, on Safari (Mac), "grudger" ends up
  always dominating on step 4, not just sometimes.