### PR TITLE
International sharing

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,9 +77,13 @@ Many thanks again!
 
 		<!-- TRANSLATE "title" & "text". Make sure it's less than 112 characters, for Twitter's sake -->
 		<!-- Also, change "link" to whatever the link for the translated version will be! -->
+		<!-- Also, translate "facebook", "twitter" & "email". -->
 		<sharing title="The Evolution of Trust"
 				 text="People no longer trust each other. Why? And how can we fix it? An interactive guide to the game theory of trust:"
-				 link="http://ncase.me/trust/"></sharing>
+				 link="http://ncase.me/trust/"
+				 facebook="Share on Facebook"
+				 twitter="Tweet"
+				 email="Send email"></sharing>				 
 
 		<!-- List of translations thus far! -->
 		<div id="translations">

--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@ Many thanks again!
 
 		<!-- TRANSLATE "title" & "text". Make sure it's less than 112 characters, for Twitter's sake -->
 		<!-- Also, change "link" to whatever the link for the translated version will be! -->
-		<!-- Also, translate "facebook", "twitter" & "email". -->
+		<!-- Also, TRANSLATE "facebook", "twitter" & "email". -->
 		<sharing title="The Evolution of Trust"
 				 text="People no longer trust each other. Why? And how can we fix it? An interactive guide to the game theory of trust:"
 				 link="http://ncase.me/trust/"

--- a/js/lib/sharing.js
+++ b/js/lib/sharing.js
@@ -10,12 +10,16 @@ window.addEventListener("load",function(){
 	text = encodeURIComponent(text);
 	link = encodeURIComponent(link);
 
+	var facebook = sharingDOM.getAttribute("facebook");
+	var twitter = sharingDOM.getAttribute("twitter");
+	var email = sharingDOM.getAttribute("email");
+
 	// Create full html
 	var sharing = document.createElement("div");
 	sharing.className = "sharing";
-	sharing.innerHTML = '<a href="https://www.facebook.com/sharer/sharer.php?u='+link+'&t='+text+'" title="Share on Facebook" target="_blank"><img alt="Share on Facebook" src="social/facebook.png"></a>'+
-						'<a href="https://twitter.com/intent/tweet?source='+link+'&text='+text+'%20'+link+'" target="_blank" title="Tweet"><img alt="Tweet" src="social/twitter.png"></a>'+
-						'<a href="mailto:?subject='+title+'&body='+text+" "+link+'" target="_blank" title="Send email"><img alt="Send email" src="social/email.png"></a>';
+	sharing.innerHTML = '<a href="https://www.facebook.com/sharer/sharer.php?u='+link+'&t='+text+'" title="'+facebook+'" target="_blank"><img alt="'+facebook+'" src="social/facebook.png"></a>'+
+                        '<a href="https://twitter.com/intent/tweet?source='+link+'&text='+text+'%20'+link+'" target="_blank" title="'+twitter+'"><img alt="'+twitter+'" src="social/twitter.png"></a>'+
+                        '<a href="mailto:?subject='+title+'&body='+text+" "+link+'" target="_blank" title="'+email+'"><img alt="'+email+'" src="social/email.png"></a>';
 
 	// Replace it in the dom
 	sharingDOM.parentNode.replaceChild(sharing, sharingDOM);


### PR DESCRIPTION
@ncase The titles (and therefore the tooltips) of the sharing buttons were not included in the translation so far. I completely understand if this change is too minor to include it.

btw: If the `<sharing>` tag has a function beyond having the text somewhere parsable, I missed it. I hope it was ok to add more attributes there.